### PR TITLE
CI problemleri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         update-comment: true
         pass-emoji: ':white_check_mark:'
         fail-emoji: ':x:'
+        debug-mode: 'true'
     - name: CodeQL Analysis # CodeQL for source code scan
       uses: github/codeql-action/init@v4
       with:


### PR DESCRIPTION
CI sorunlari (tarama sonuclarini Github API uzerinden kaydetmek vs) kullanilan pluginlerin yazma yetkisi olmamasindan kaynakli gorunuyor.