### PR TITLE
feat(geocoding): Nominatim geocoding service + business coordinate backfill (#19)

### DIFF
--- a/docs/adr/ADR-001-mandatory-business-coordinates-and-geocoding.md
+++ b/docs/adr/ADR-001-mandatory-business-coordinates-and-geocoding.md
@@ -1,0 +1,138 @@
+# ADR-001: Mandatory business coordinates and server-side geocoding
+
+- **Status:** Accepted
+- **Date:** 2026-06-07
+- **Related:** GitHub issue [#19](https://github.com/Yasin4261/i-need-courier/issues/19)
+- **Deciders:** Project owner
+
+## Context
+
+`BusinessOrderServiceImpl.createOrder()` fabricates **random coordinates** around
+Kadıköy (40.9907, 29.0245) for orders:
+
+- **Pickup**: uses the business's `latitude`/`longitude` when present, otherwise a
+  random point near Kadıköy.
+- **Delivery**: *always* a random point near Kadıköy.
+
+`V18__Add_order_coordinates.sql` does the same (via SQL `random()`) for existing
+order rows and for coordinate-less businesses.
+
+This was a stop-gap to give the map feature something to render. Problems:
+
+- The data is fabricated and misleading — couriers/businesses see fake locations.
+- It is non-deterministic (`Math.random()` / SQL `random()`).
+- There is no geocoding integration, so there is no real source of truth for
+  coordinates.
+
+Current constraints in the codebase:
+
+- `Business.latitude` / `longitude` are nullable (`@Column private Double`); DB
+  columns are nullable (added in `V3`).
+- `BusinessRegistrationRequest` collects an `address` but **no** coordinates, and
+  registration never sets lat/lng.
+- There is no HTTP client, geocoding code, or related configuration yet.
+- Real coordinate data for existing businesses is **not yet in the database** —
+  this is the blocker the random fallback was papering over.
+
+## Decision
+
+Make business coordinates mandatory and source all coordinates from real data via
+server-side geocoding, removing every random fallback.
+
+### 1. Geocoding abstraction (`com.api.pako.service.geocoding`)
+
+- `GeocodingService` interface: `Optional<Coordinates> geocode(String address)`
+  (`Coordinates` = lat/lng record).
+- `NominatimGeocodingService` implementation using Spring's `RestClient`
+  (synchronous, fits the project's virtual threads):
+  - Configurable base URL and identifying `User-Agent` header (required by the
+    Nominatim usage policy).
+  - Query params `format=jsonv2&limit=1&countrycodes=tr`.
+  - A 1 request/second throttle to honor the public-instance policy.
+- Cache `geocode(...)` results in Redis (already in the stack, via Spring Cache);
+  delivery addresses repeat, and this is the issue's recommended mitigation.
+- Configuration in `application.properties`: `geocoding.nominatim.base-url`,
+  `geocoding.user-agent`, `geocoding.rate-limit-per-second`, plus an enable toggle.
+
+### 2. Coordinate source — **always server-side geocode**
+
+- No latitude/longitude fields are added to request DTOs.
+- Business registration/update geocodes the `address`.
+- Order delivery geocodes the `deliveryAddress`.
+- Order pickup is derived from the business location (now guaranteed present).
+
+### 3. Failure handling — **reject with a clear error**
+
+- If geocoding yields no result and no coordinates are available, fail the
+  operation with a clear `4xx` error. A business or order is never persisted
+  without real coordinates. No random/placeholder data is ever stored.
+
+### 4. Business coordinates become mandatory
+
+- Registration/update: geocode `address`; on failure throw a clear `400`.
+- Entity: `Business.latitude` / `longitude` become `@Column(nullable = false)`.
+- A new migration adds the `NOT NULL` constraint at the DB level — shipped **only
+  after** the backfill has populated real data.
+
+### 5. Order creation
+
+- Pickup ← business coordinates (defensive throw if somehow null).
+- Delivery ← geocode `deliveryAddress`; reject creation on failure.
+- Remove the random block and the `// TODO(#19)` from `createOrder()`.
+
+### 6. Backfill — **idempotent startup runner**
+
+- An `ApplicationRunner` finds businesses with null coordinates, geocodes their
+  `address` at ≤1 req/s, and saves them. The same pass re-geocodes the random
+  `orders` rows. It is idempotent, logged, and safe to re-run.
+- Flyway SQL cannot call Nominatim, so the backfill lives in Java rather than in a
+  migration.
+
+### 7. Migrations
+
+- `V18` is already applied and its checksum is immutable, so it is **not** edited;
+  a new migration supersedes its random values where needed.
+- The `NOT NULL` migration ships only after the backfill runner has verified real
+  data is present.
+
+## Rollout phasing
+
+1. Geocoding service + config + tests (no behavior change).
+2. Backfill runner; run it; verify real coordinates landed.
+3. Wire pickup/delivery into `createOrder()`, remove random, enforce on registration.
+4. `NOT NULL` migration + registration/update enforcement.
+
+## Consequences
+
+**Positive**
+
+- Coordinates reflect real locations; the map shows truthful data.
+- Deterministic — no more values that change between reads.
+- A single source of truth (`GeocodingService`) for all coordinate resolution.
+- The mandatory non-null constraint is enforced at validation **and** DB level.
+
+**Negative / trade-offs**
+
+- Runtime dependency on Nominatim for registration and order creation. Mitigated
+  by Redis caching and confined to address-changing operations.
+- Registration/order creation can now fail if an address cannot be geocoded;
+  surfaced as a clear `4xx` so the client can correct the address.
+- The public Nominatim instance caps at 1 req/s and forbids bulk geocoding; the
+  throttle keeps us compliant while volume is low.
+
+**Future / revisit when volume grows**
+
+- Self-host Nominatim, or move to a paid provider (Google Maps, Mapbox, OpenCage,
+  HERE, LocationIQ) for higher throughput and SLAs.
+- Consider re-introducing a client-supplied-coordinates path (e.g. a frontend map
+  picker) to reduce geocoding load if needed.
+
+## Alternatives considered
+
+- **Client-supplied coordinates (with geocode fallback / only):** rejected for now
+  in favor of a single server-side source of truth; can be revisited as a
+  throughput mitigation.
+- **Allow null coordinates and resolve asynchronously:** rejected — it weakens the
+  mandatory constraint and needs a retry/queue mechanism.
+- **Flyway Java migration for backfill:** rejected — network calls inside the
+  migration pipeline are riskier and harder to retry than an idempotent runner.

--- a/src/main/java/com/api/pako/config/GeocodingConfig.java
+++ b/src/main/java/com/api/pako/config/GeocodingConfig.java
@@ -1,0 +1,12 @@
+package com.api.pako.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Enables {@link GeocodingProperties} binding for the geocoding service.
+ */
+@Configuration
+@EnableConfigurationProperties(GeocodingProperties.class)
+public class GeocodingConfig {
+}

--- a/src/main/java/com/api/pako/config/GeocodingConfig.java
+++ b/src/main/java/com/api/pako/config/GeocodingConfig.java
@@ -1,12 +1,24 @@
 package com.api.pako.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
 /**
- * Enables {@link GeocodingProperties} binding for the geocoding service.
+ * Enables {@link GeocodingProperties} binding and provides the {@link RestClient} used by the
+ * geocoding service, pre-configured with the base URL and the identifying {@code User-Agent}
+ * required by the Nominatim usage policy.
  */
 @Configuration
 @EnableConfigurationProperties(GeocodingProperties.class)
 public class GeocodingConfig {
+
+    @Bean
+    RestClient geocodingRestClient(GeocodingProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.getNominatim().getBaseUrl())
+                .defaultHeader("User-Agent", properties.getUserAgent())
+                .build();
+    }
 }

--- a/src/main/java/com/api/pako/config/GeocodingProperties.java
+++ b/src/main/java/com/api/pako/config/GeocodingProperties.java
@@ -31,6 +31,8 @@ public class GeocodingProperties {
 
     private final Nominatim nominatim = new Nominatim();
 
+    private final Backfill backfill = new Backfill();
+
     @Getter
     @Setter
     public static class Nominatim {
@@ -40,5 +42,16 @@ public class GeocodingProperties {
 
         /** ISO country code(s) used to bias/limit results, e.g. {@code tr}. */
         private String countryCodes = "tr";
+    }
+
+    @Getter
+    @Setter
+    public static class Backfill {
+
+        /**
+         * When {@code true}, the startup runner geocodes businesses that are still missing
+         * coordinates. Disable to skip the network calls (e.g. in offline/CI environments).
+         */
+        private boolean enabled = true;
     }
 }

--- a/src/main/java/com/api/pako/config/GeocodingProperties.java
+++ b/src/main/java/com/api/pako/config/GeocodingProperties.java
@@ -1,0 +1,44 @@
+package com.api.pako.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for address geocoding (see docs/adr/ADR-001).
+ *
+ * <p>Bound from the {@code geocoding.*} namespace in application properties.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "geocoding")
+public class GeocodingProperties {
+
+    /** When {@code false}, the geocoding service short-circuits and resolves nothing. */
+    private boolean enabled = true;
+
+    /**
+     * Identifying {@code User-Agent} header sent with every request. The Nominatim usage
+     * policy requires a valid identifying header — anonymous requests may be blocked.
+     */
+    private String userAgent = "i-need-courier/1.0 (+https://github.com/Yasin4261/i-need-courier)";
+
+    /**
+     * Maximum requests per second to the geocoder. The public Nominatim instance allows at
+     * most 1 req/s. A value {@code <= 0} disables throttling (useful in tests).
+     */
+    private double rateLimitPerSecond = 1.0;
+
+    private final Nominatim nominatim = new Nominatim();
+
+    @Getter
+    @Setter
+    public static class Nominatim {
+
+        /** Base URL of the Nominatim instance. */
+        private String baseUrl = "https://nominatim.openstreetmap.org";
+
+        /** ISO country code(s) used to bias/limit results, e.g. {@code tr}. */
+        private String countryCodes = "tr";
+    }
+}

--- a/src/main/java/com/api/pako/repository/BusinessRepository.java
+++ b/src/main/java/com/api/pako/repository/BusinessRepository.java
@@ -4,6 +4,7 @@ import com.api.pako.model.Business;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -52,5 +53,12 @@ public interface BusinessRepository extends JpaRepository<Business, Long> {
      * @return true if exists, false otherwise
      */
     boolean existsByPhone(String phone);
+
+    /**
+     * Find businesses that are missing coordinates and need geocoding backfill.
+     *
+     * @return businesses whose latitude or longitude is null
+     */
+    List<Business> findByLatitudeIsNullOrLongitudeIsNull();
 }
 

--- a/src/main/java/com/api/pako/service/geocoding/BusinessCoordinateBackfillRunner.java
+++ b/src/main/java/com/api/pako/service/geocoding/BusinessCoordinateBackfillRunner.java
@@ -1,0 +1,72 @@
+package com.api.pako.service.geocoding;
+
+import com.api.pako.config.GeocodingProperties;
+import com.api.pako.repository.BusinessRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills coordinates for businesses that are missing them, on application startup.
+ *
+ * <p>Phase 2 of issue #19 / ADR-001. Each coordinate-less business has its address geocoded
+ * and its location persisted. The work is:
+ * <ul>
+ *   <li><b>idempotent</b> — only businesses still missing coordinates are processed, so a
+ *       re-run (e.g. another boot) does no redundant work;</li>
+ *   <li><b>self-throttling</b> — {@link GeocodingService} already serialises outbound calls to
+ *       the configured rate (≤1 req/s), so iterating here cannot breach the Nominatim policy;</li>
+ *   <li><b>fault-tolerant</b> — a business that cannot be geocoded is left untouched and retried
+ *       on the next startup; one save per business keeps partial progress.</li>
+ * </ul>
+ */
+@Component
+@Slf4j
+public class BusinessCoordinateBackfillRunner implements ApplicationRunner {
+
+    private final GeocodingProperties properties;
+    private final BusinessRepository businessRepository;
+    private final GeocodingService geocodingService;
+
+    public BusinessCoordinateBackfillRunner(GeocodingProperties properties,
+                                            BusinessRepository businessRepository,
+                                            GeocodingService geocodingService) {
+        this.properties = properties;
+        this.businessRepository = businessRepository;
+        this.geocodingService = geocodingService;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!properties.getBackfill().isEnabled()) {
+            log.info("Business coordinate backfill is disabled; skipping.");
+            return;
+        }
+
+        var pending = businessRepository.findByLatitudeIsNullOrLongitudeIsNull();
+        if (pending.isEmpty()) {
+            log.info("Business coordinate backfill: no businesses need coordinates.");
+            return;
+        }
+
+        log.info("Business coordinate backfill: {} business(es) need coordinates.", pending.size());
+        var succeeded = 0;
+        var failed = 0;
+        for (var business : pending) {
+            var coordinates = geocodingService.geocode(business.getAddress());
+            if (coordinates.isPresent()) {
+                business.setLatitude(coordinates.get().latitude());
+                business.setLongitude(coordinates.get().longitude());
+                businessRepository.save(business);
+                succeeded++;
+                log.debug("Backfilled coordinates for business {} ({}).", business.getId(), business.getName());
+            } else {
+                failed++;
+                log.warn("Could not geocode address for business {} ({}); will retry on next startup.",
+                        business.getId(), business.getName());
+            }
+        }
+        log.info("Business coordinate backfill complete: {} succeeded, {} failed.", succeeded, failed);
+    }
+}

--- a/src/main/java/com/api/pako/service/geocoding/Coordinates.java
+++ b/src/main/java/com/api/pako/service/geocoding/Coordinates.java
@@ -1,0 +1,10 @@
+package com.api.pako.service.geocoding;
+
+/**
+ * A geographic point resolved from an address.
+ *
+ * @param latitude  WGS84 latitude in decimal degrees
+ * @param longitude WGS84 longitude in decimal degrees
+ */
+public record Coordinates(double latitude, double longitude) {
+}

--- a/src/main/java/com/api/pako/service/geocoding/GeocodingService.java
+++ b/src/main/java/com/api/pako/service/geocoding/GeocodingService.java
@@ -1,0 +1,21 @@
+package com.api.pako.service.geocoding;
+
+import java.util.Optional;
+
+/**
+ * Resolves a free-text address into geographic coordinates.
+ *
+ * <p>The single source of truth for coordinates across the system (see docs/adr/ADR-001):
+ * business locations and order delivery points are derived from here rather than fabricated.
+ */
+public interface GeocodingService {
+
+    /**
+     * Resolve the given address to coordinates.
+     *
+     * @param address free-text postal address
+     * @return the resolved coordinates, or {@link Optional#empty()} if the address could not
+     * be resolved (no match, blank input, geocoding disabled, or an upstream failure)
+     */
+    Optional<Coordinates> geocode(String address);
+}

--- a/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
+++ b/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
@@ -1,0 +1,115 @@
+package com.api.pako.service.geocoding;
+
+import com.api.pako.config.GeocodingProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * {@link GeocodingService} backed by an OpenStreetMap Nominatim instance.
+ *
+ * <p>Honours the Nominatim usage policy: an identifying {@code User-Agent} header is sent on
+ * every request and calls are throttled to the configured rate (default 1 req/s). Any failure
+ * — no match, malformed payload, or transport error — resolves to {@link Optional#empty()};
+ * callers decide how to react (see docs/adr/ADR-001).
+ */
+@Service
+@Slf4j
+public class NominatimGeocodingService implements GeocodingService {
+
+    private final GeocodingProperties properties;
+    private final RestClient restClient;
+
+    /** Serialises outbound calls so the configured rate limit is enforced process-wide. */
+    private final ReentrantLock throttleLock = new ReentrantLock(true);
+    private long lastRequestAtNanos;
+
+    public NominatimGeocodingService(GeocodingProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = restClientBuilder
+                .baseUrl(properties.getNominatim().getBaseUrl())
+                .defaultHeader("User-Agent", properties.getUserAgent())
+                .build();
+    }
+
+    @Override
+    public Optional<Coordinates> geocode(String address) {
+        if (!properties.isEnabled()) {
+            log.debug("Geocoding is disabled; skipping lookup for address: {}", address);
+            return Optional.empty();
+        }
+        if (address == null || address.isBlank()) {
+            return Optional.empty();
+        }
+
+        throttle();
+
+        try {
+            var results = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/search")
+                            .queryParam("q", address)
+                            .queryParam("format", "jsonv2")
+                            .queryParam("limit", 1)
+                            .queryParam("countrycodes", properties.getNominatim().getCountryCodes())
+                            .build())
+                    .retrieve()
+                    .body(NominatimResult[].class);
+
+            if (results == null || results.length == 0) {
+                log.warn("No geocoding result for address: {}", address);
+                return Optional.empty();
+            }
+            return results[0].toCoordinates();
+        } catch (RestClientException ex) {
+            log.warn("Geocoding request failed for address '{}': {}", address, ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Block until at least {@code 1 / rateLimitPerSecond} seconds have elapsed since the last
+     * outbound call. Skipped entirely when the rate limit is non-positive.
+     */
+    private void throttle() {
+        var rate = properties.getRateLimitPerSecond();
+        if (rate <= 0) {
+            return;
+        }
+        var minIntervalNanos = (long) (1_000_000_000L / rate);
+        throttleLock.lock();
+        try {
+            var waitNanos = (lastRequestAtNanos + minIntervalNanos) - System.nanoTime();
+            if (waitNanos > 0) {
+                Thread.sleep(Duration.ofNanos(waitNanos));
+            }
+            lastRequestAtNanos = System.nanoTime();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        } finally {
+            throttleLock.unlock();
+        }
+    }
+
+    /**
+     * Subset of a Nominatim search result. Coordinates arrive as strings in the JSON payload.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record NominatimResult(String lat, String lon, @JsonProperty("display_name") String displayName) {
+
+        Optional<Coordinates> toCoordinates() {
+            try {
+                return Optional.of(new Coordinates(Double.parseDouble(lat), Double.parseDouble(lon)));
+            } catch (NumberFormatException ex) {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
+++ b/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
@@ -31,12 +31,9 @@ public class NominatimGeocodingService implements GeocodingService {
     private final ReentrantLock throttleLock = new ReentrantLock(true);
     private long lastRequestAtNanos;
 
-    public NominatimGeocodingService(GeocodingProperties properties, RestClient.Builder restClientBuilder) {
+    public NominatimGeocodingService(GeocodingProperties properties, RestClient geocodingRestClient) {
         this.properties = properties;
-        this.restClient = restClientBuilder
-                .baseUrl(properties.getNominatim().getBaseUrl())
-                .defaultHeader("User-Agent", properties.getUserAgent())
-                .build();
+        this.restClient = geocodingRestClient;
     }
 
     @Override

--- a/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
+++ b/src/main/java/com/api/pako/service/geocoding/NominatimGeocodingService.java
@@ -46,13 +46,15 @@ public class NominatimGeocodingService implements GeocodingService {
             return Optional.empty();
         }
 
+        var query = normalize(address);
+
         throttle();
 
         try {
             var results = restClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/search")
-                            .queryParam("q", address)
+                            .queryParam("q", query)
                             .queryParam("format", "jsonv2")
                             .queryParam("limit", 1)
                             .queryParam("countrycodes", properties.getNominatim().getCountryCodes())
@@ -69,6 +71,26 @@ public class NominatimGeocodingService implements GeocodingService {
             log.warn("Geocoding request failed for address '{}': {}", address, ex.getMessage());
             return Optional.empty();
         }
+    }
+
+    /**
+     * Clean up a free-text address to improve the geocoder's hit rate. Turkish addresses are
+     * often written with slash-separated districts and abbreviated street types (e.g.
+     * {@code "... Moda Cad. No:15 Kadıköy/İstanbul"}), which the public Nominatim instance
+     * struggles to match. This expands the common abbreviations, turns {@code /} separators
+     * into commas, and collapses redundant whitespace.
+     */
+    private String normalize(String address) {
+        return address.strip()
+                .replace('/', ',')
+                .replaceAll("(?i)\\bMah\\.", "Mahallesi")
+                .replaceAll("(?i)\\bCad\\.", "Caddesi")
+                .replaceAll("(?i)\\bSok\\.", "Sokak")
+                .replaceAll("(?i)\\bBulv\\.", "Bulvarı")
+                .replaceAll("(?i)\\bApt\\.", "Apartmanı")
+                .replaceAll("\\s*,\\s*", ", ")
+                .replaceAll("\\s+", " ")
+                .strip();
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,6 +68,8 @@ geocoding.user-agent=i-need-courier/1.0 (+https://github.com/Yasin4261/i-need-co
 geocoding.rate-limit-per-second=1
 geocoding.nominatim.base-url=https://nominatim.openstreetmap.org
 geocoding.nominatim.country-codes=tr
+# Startup backfill of coordinate-less businesses (idempotent).
+geocoding.backfill.enabled=true
 
 # Swagger/OpenAPI Configuration
 springdoc.api-docs.path=/v3/api-docs

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,6 +61,14 @@ logging.level.com.api.pako=ERROR
 jwt.secret=myVerySecretJwtKey123456789012345678901234567890
 jwt.expiration.hours=24
 
+# Geocoding (Nominatim) Configuration — see docs/adr/ADR-001
+# Public instance allows max 1 req/s and requires an identifying User-Agent.
+geocoding.enabled=true
+geocoding.user-agent=i-need-courier/1.0 (+https://github.com/Yasin4261/i-need-courier)
+geocoding.rate-limit-per-second=1
+geocoding.nominatim.base-url=https://nominatim.openstreetmap.org
+geocoding.nominatim.country-codes=tr
+
 # Swagger/OpenAPI Configuration
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html

--- a/src/main/resources/db/migration/V19__Reset_fabricated_business_coordinates.sql
+++ b/src/main/resources/db/migration/V19__Reset_fabricated_business_coordinates.sql
@@ -1,0 +1,12 @@
+-- V19: Reset fabricated (random) business coordinates so they can be backfilled with real data.
+--
+-- V18 filled coordinate-less businesses with random points around Kadıköy as a map stop-gap.
+-- No real coordinate data existed yet (see issue #19 / docs/adr/ADR-001), so every existing
+-- business currently holds fabricated coordinates that cannot be told apart from real ones.
+--
+-- We null them here so that BusinessCoordinateBackfillRunner repopulates them on the next
+-- startup by geocoding each business's address (≤1 req/s, Nominatim). This supersedes V18's
+-- random business fill without editing the already-applied V18 (whose checksum is immutable).
+UPDATE businesses
+SET latitude  = NULL,
+    longitude = NULL;

--- a/src/test/java/com/api/pako/service/geocoding/BusinessCoordinateBackfillRunnerTest.java
+++ b/src/test/java/com/api/pako/service/geocoding/BusinessCoordinateBackfillRunnerTest.java
@@ -1,0 +1,126 @@
+package com.api.pako.service.geocoding;
+
+import com.api.pako.config.GeocodingProperties;
+import com.api.pako.model.Business;
+import com.api.pako.repository.BusinessRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BusinessCoordinateBackfillRunnerTest {
+
+    @Mock
+    private BusinessRepository businessRepository;
+
+    @Mock
+    private GeocodingService geocodingService;
+
+    private GeocodingProperties properties;
+    private BusinessCoordinateBackfillRunner underTest;
+
+    @BeforeEach
+    void setUp() {
+        properties = new GeocodingProperties();
+        properties.getBackfill().setEnabled(true);
+        underTest = new BusinessCoordinateBackfillRunner(properties, businessRepository, geocodingService);
+    }
+
+    @Test
+    void backfillsCoordinatesForGeocodableBusiness() {
+        // GIVEN
+        var business = businessWithAddress(1L, "Bagdat Caddesi 100, Istanbul");
+        when(businessRepository.findByLatitudeIsNullOrLongitudeIsNull()).thenReturn(List.of(business));
+        when(geocodingService.geocode("Bagdat Caddesi 100, Istanbul"))
+                .thenReturn(Optional.of(new Coordinates(40.9906, 29.0246)));
+
+        // WHEN
+        underTest.run(null);
+
+        // THEN
+        verify(businessRepository).save(assertArg(saved -> {
+            assertThat(saved.getLatitude()).isEqualTo(40.9906);
+            assertThat(saved.getLongitude()).isEqualTo(29.0246);
+        }));
+    }
+
+    @Test
+    void leavesBusinessUntouchedWhenGeocodingFails() {
+        // GIVEN
+        var business = businessWithAddress(2L, "unresolvable address");
+        when(businessRepository.findByLatitudeIsNullOrLongitudeIsNull()).thenReturn(List.of(business));
+        when(geocodingService.geocode("unresolvable address")).thenReturn(Optional.empty());
+
+        // WHEN
+        underTest.run(null);
+
+        // THEN - nothing saved, coordinates remain null for a retry on the next startup
+        verify(businessRepository, never()).save(any());
+        assertThat(business.getLatitude()).isNull();
+        assertThat(business.getLongitude()).isNull();
+    }
+
+    @Test
+    void savesOnlyTheBusinessesThatCouldBeGeocoded() {
+        // GIVEN
+        var resolvable = businessWithAddress(1L, "good address");
+        var unresolvable = businessWithAddress(2L, "bad address");
+        when(businessRepository.findByLatitudeIsNullOrLongitudeIsNull())
+                .thenReturn(List.of(resolvable, unresolvable));
+        when(geocodingService.geocode("good address")).thenReturn(Optional.of(new Coordinates(41.0, 29.0)));
+        when(geocodingService.geocode("bad address")).thenReturn(Optional.empty());
+
+        // WHEN
+        underTest.run(null);
+
+        // THEN - exactly one save, for the resolvable business
+        verify(businessRepository).save(assertArg(saved -> assertThat(saved.getId()).isEqualTo(1L)));
+    }
+
+    @Test
+    void doesNothingWhenNoBusinessesNeedCoordinates() {
+        // GIVEN
+        when(businessRepository.findByLatitudeIsNullOrLongitudeIsNull()).thenReturn(List.of());
+
+        // WHEN
+        underTest.run(null);
+
+        // THEN
+        verifyNoInteractions(geocodingService);
+        verify(businessRepository, never()).save(any());
+    }
+
+    @Test
+    void skipsEntirelyWhenBackfillDisabled() {
+        // GIVEN
+        properties.getBackfill().setEnabled(false);
+
+        // WHEN
+        underTest.run(null);
+
+        // THEN - not even the lookup query runs
+        verifyNoInteractions(businessRepository, geocodingService);
+    }
+
+    private static Business businessWithAddress(Long id, String address) {
+        var business = new Business();
+        business.setId(id);
+        business.setName("Business " + id);
+        business.setAddress(address);
+        return business;
+    }
+}

--- a/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
+++ b/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
@@ -69,6 +69,23 @@ class NominatimGeocodingServiceTest {
     }
 
     @Test
+    void normalizesAbbreviationsAndSeparatorsBeforeQuerying() {
+        // GIVEN a messy Turkish-style address: abbreviated street type, slash-separated
+        // district, and irregular whitespace
+        server.expect(requestTo(startsWith("https://nominatim.test/search")))
+                // expanded "Cad." -> "Caddesi", "/" -> ", ", and collapsed whitespace
+                .andExpect(queryParam("q", "Moda%20Caddesi%20Besiktas,%20Istanbul"))
+                .andRespond(withSuccess("[{\"lat\":\"41.0\",\"lon\":\"29.0\"}]", MediaType.APPLICATION_JSON));
+
+        // WHEN
+        var result = underTest.geocode("Moda Cad.  Besiktas / Istanbul");
+
+        // THEN
+        assertThat(result).isPresent();
+        server.verify();
+    }
+
+    @Test
     void returnsEmptyWhenNoMatch() {
         // GIVEN
         server.expect(requestTo(startsWith("https://nominatim.test/search")))

--- a/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
+++ b/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
@@ -34,7 +34,11 @@ class NominatimGeocodingServiceTest {
 
         var builder = RestClient.builder();
         server = MockRestServiceServer.bindTo(builder).build();
-        underTest = new NominatimGeocodingService(properties, builder);
+        var restClient = builder
+                .baseUrl(properties.getNominatim().getBaseUrl())
+                .defaultHeader("User-Agent", properties.getUserAgent())
+                .build();
+        underTest = new NominatimGeocodingService(properties, restClient);
     }
 
     @Test

--- a/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
+++ b/src/test/java/com/api/pako/service/geocoding/NominatimGeocodingServiceTest.java
@@ -1,0 +1,120 @@
+package com.api.pako.service.geocoding;
+
+import com.api.pako.config.GeocodingProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.http.HttpMethod.GET;
+
+class NominatimGeocodingServiceTest {
+
+    private GeocodingProperties properties;
+    private MockRestServiceServer server;
+    private NominatimGeocodingService underTest;
+
+    @BeforeEach
+    void setUp() {
+        properties = new GeocodingProperties();
+        properties.setEnabled(true);
+        properties.setUserAgent("test-agent/1.0");
+        properties.setRateLimitPerSecond(0); // disable throttling so tests stay fast
+        properties.getNominatim().setBaseUrl("https://nominatim.test");
+        properties.getNominatim().setCountryCodes("tr");
+
+        var builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        underTest = new NominatimGeocodingService(properties, builder);
+    }
+
+    @Test
+    void resolvesCoordinatesAndSendsCompliantRequest() {
+        // GIVEN
+        var body = """
+                [{"lat":"40.9906","lon":"29.0246","display_name":"Kadikoy, Istanbul, Turkiye"}]
+                """;
+        server.expect(requestTo(startsWith("https://nominatim.test/search")))
+                .andExpect(method(GET))
+                // MockRestServiceServer compares the raw (URL-encoded) query value
+                .andExpect(queryParam("q", "Bagdat%20Caddesi%20100,%20Istanbul"))
+                .andExpect(queryParam("format", "jsonv2"))
+                .andExpect(queryParam("limit", "1"))
+                .andExpect(queryParam("countrycodes", "tr"))
+                .andExpect(header("User-Agent", "test-agent/1.0"))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        // WHEN
+        var result = underTest.geocode("Bagdat Caddesi 100, Istanbul");
+
+        // THEN
+        assertThat(result).hasValueSatisfying(coordinates -> {
+            assertThat(coordinates.latitude()).isEqualTo(40.9906);
+            assertThat(coordinates.longitude()).isEqualTo(29.0246);
+        });
+        server.verify();
+    }
+
+    @Test
+    void returnsEmptyWhenNoMatch() {
+        // GIVEN
+        server.expect(requestTo(startsWith("https://nominatim.test/search")))
+                .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+        // WHEN / THEN
+        assertThat(underTest.geocode("nowhere at all")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void returnsEmptyOnUpstreamServerError() {
+        // GIVEN
+        server.expect(requestTo(startsWith("https://nominatim.test/search")))
+                .andRespond(withServerError());
+
+        // WHEN / THEN - transport failure must not propagate
+        assertThat(underTest.geocode("Bagdat Caddesi 100, Istanbul")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void returnsEmptyWhenLatLonAreNotNumeric() {
+        // GIVEN
+        var body = """
+                [{"lat":"not-a-number","lon":"29.0246","display_name":"broken"}]
+                """;
+        server.expect(requestTo(startsWith("https://nominatim.test/search")))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        // WHEN / THEN
+        assertThat(underTest.geocode("Bagdat Caddesi 100, Istanbul")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void resolvesNothingAndSkipsRequestWhenDisabled() {
+        // GIVEN geocoding is turned off
+        properties.setEnabled(false);
+
+        // WHEN / THEN - no HTTP call is made
+        assertThat(underTest.geocode("Bagdat Caddesi 100, Istanbul")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void resolvesNothingAndSkipsRequestForBlankAddress() {
+        // WHEN / THEN - blank input short-circuits before any HTTP call
+        assertThat(underTest.geocode("   ")).isEmpty();
+        assertThat(underTest.geocode(null)).isEmpty();
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary

Phases 1–2 of issue #19 / ADR-001. Adds the geocoding adapter and backfills existing businesses with real coordinates. **No change to the order-creation / registration random fallback yet** — that is phase 3.

### Phase 1 — geocoding adapter
- `GeocodingService` interface + `Coordinates` record — the contract callers will use.
- `NominatimGeocodingService` — `RestClient` adapter honouring the Nominatim usage policy: identifying `User-Agent` and a configurable ≥1s throttle (fair `ReentrantLock`, virtual-thread friendly). Any failure — no match, malformed payload, transport error — resolves to `Optional.empty()`; callers decide policy.
- `GeocodingProperties` / `GeocodingConfig` + `application.properties` defaults.
- Design recorded in `docs/adr/ADR-001`.

### Phase 2 — startup backfill
- `V19` migration nulls the random business coordinates V18 fabricated (no real data existed yet, so nulling is safe; V18 untouched).
- `BusinessCoordinateBackfillRunner` (`ApplicationRunner`): geocodes every coordinate-less business at startup and persists it. Idempotent (only null-coord rows), self-throttling (rate limit lives in the service), fault-tolerant (failed lookups retried next boot).
- `BusinessRepository.findByLatitudeIsNullOrLongitudeIsNull()` + `geocoding.backfill.enabled` toggle.

## Testing

`./mvnw test -Dtest=NominatimGeocodingServiceTest,BusinessCoordinateBackfillRunnerTest,ConventionsTest` → 14 run, 0 failures.

- `NominatimGeocodingServiceTest` (`MockRestServiceServer`): request compliance + every empty-resolution path.
- `BusinessCoordinateBackfillRunnerTest`: success, geocode failure, partial success, empty, disabled.

## Deferred (follow-up phases)

- Redis caching of lookups.
- Historical **order** coordinate backfill (V18 also randomised orders).
- Phase 3: wire pickup/delivery into `createOrder()` + registration, remove random fallback.
- Phase 4: `NOT NULL` migration on `businesses.latitude/longitude`.

Refs #19